### PR TITLE
Changes to support Windows builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,9 +35,6 @@ endif()
 # Set CPP standard to C++11 minimum.
 set(CMAKE_CXX_STANDARD 11)
 
-# Because Shiboken does not support templated classes
-set(qwtaddons_library "libqwtaddons")
-
 # Find QWT library
 find_package(Qwt REQUIRED)
 
@@ -242,29 +239,6 @@ foreach(include_dir ${pyside2_include_dir})
     list(APPEND pyside2_additional_includes "${include_dir}/QtWidgets")
 endforeach()
 
-# =============================== CMake target - qwtaddons_library ===============================
-
-
-# Define the sample shared library for which we will create bindings.
-#set(${qwtaddons_library}_sources )
-#add_library(${qwtaddons_library} SHARED ${${qwtaddons_library}_sources})
-#set_property(TARGET ${qwtaddons_library} PROPERTY PREFIX "")
-
-# Needed mostly on Windows to export symbols, and create a .lib file, otherwise the binding
-# library can't link to the sample library.
-#target_compile_definitions(${qwtaddons_library} PRIVATE BINDINGS_BUILD)
-
-# Apply relevant include and link flags.
-#target_include_directories(${qwtaddons_library} PRIVATE ${QWT_INCLUDE_DIR})
-#target_include_directories(${qwtaddons_library} PRIVATE ${python_include_dir})
-#target_include_directories(${qwtaddons_library} PRIVATE ${shiboken2_generator_include_dir})
-#target_include_directories(${qwtaddons_library} PRIVATE ${pyside2_include_dir})
-#target_include_directories(${qwtaddons_library} PRIVATE ${pyside2_additional_includes})
-#target_include_directories(${qwtaddons_library} PRIVATE ${CMAKE_SOURCE_DIR})
-
-#target_link_libraries(${qwtaddons_library} PRIVATE ${QWT_LIBRARY})
-#target_link_libraries(${qwtaddons_library} PRIVATE Qt5::Widgets)
-
 # =============================== CMake target - bindings_library =============================
 
 
@@ -286,7 +260,6 @@ target_include_directories(${bindings_library} PRIVATE ${pyside2_additional_incl
 target_include_directories(${bindings_library} PRIVATE ${CMAKE_SOURCE_DIR})
 
 target_link_libraries(${bindings_library} PRIVATE ${shiboken2_module_shared_libraries})
-#target_link_libraries(${bindings_library} PRIVATE ${qwtaddons_library})
 target_link_libraries(${bindings_library} PRIVATE ${QWT_LIBRARY})
 target_link_libraries(${bindings_library} PRIVATE Qt5::Widgets)
 target_link_libraries(${bindings_library} PRIVATE ${pyside2_shared_libraries})
@@ -377,10 +350,6 @@ install(TARGETS ${bindings_library}
         LIBRARY DESTINATION ${CMAKE_CURRENT_SOURCE_DIR}/package/pysideqwt
         RUNTIME DESTINATION ${CMAKE_CURRENT_SOURCE_DIR}/package/pysideqwt
         )
-if(WIN32)
-    install(FILES "${CMAKE_CURRENT_BINARY_DIR}/${qwtaddons_library}.lib"
-        DESTINATION "${CMAKE_CURRENT_SOURCE_DIR}/package/pysideqwt")
-endif()
 
 # Qwt seems to be built with no rpath support, so to load the generated module, the framework
 # has to be copied to the same folder as the .so file. 

--- a/README.md
+++ b/README.md
@@ -2,35 +2,45 @@
 
 ### Dependencies
 
-* Qt 5.12+ (tested with Qt 5.12.0)
+* Qt 5.12+ (tested with Qt 5.12.4)
   You can use the version installable from your qt.io account at:
       https://account.qt.io/downloads
   Or you can use one of the offline installers located at:
-      https://download.qt.io/official_releases/qt/5.12/5.12.0/qt-opensource-windows-x86-5.12.0.exe
+      https://download.qt.io/official_releases/qt/5.12/5.12.4/qt-opensource-windows-x86-5.12.4.exe
 
-  On windows, if you install Qt to a location other than the deafult (C:\Qt) or
-  install a version other than 5.12.0, you will need to modify setup.bat,
-  changing the -DQt5_DIR= argument to cmake to point to the location of the
-  cmake modules inside of your Qt installation. it will take the form of:
-      <Path to Qt dir>\<Qt version #>\msvc2017_64\lib\cmake\Qt5
+  In order for Qt to be found properly, you need to do one of the following:
+    * Add <Qt Dir>/bin to your path so qmake can be found.
+    * On Windows, use Qt version 5.12.4, installed to the default location of
+      C:\Qt\5.12.4.
+    * On Windows, edit setup.bat, modifying cmake command line option -DQt5_DIR=
+      to point to the location of the Qt5 cmake module files inside your Qt
+      installation like so:
+        -DQt5_DIR=<Path to Qt dir>\<Qt version #>\msvc2017_64\lib\cmake\Qt5
 
 * PySide2 installed. Please try to match the Qt version and PySide2 version.
   See: https://wiki.qt.io/Qt_for_Python/GettingStarted
+  * For Windows, please build PySide2 from sources, following the instructions
+    in README.pyside2.md.
+    If you do not, you may find issues with Visual Studio headers complaining
+    that your CLANG version is too old (VS2017 headers require CLang v7+)
 
-* Qwt 6.2.x (as of 20180920, only available via SVN checkout, qwt-6.2 branch)
-    * Check the code out using this subversion command line:
-      $ svn checkout svn://svn.code.sf.net/p/qwt/code/branches/qwt-6.2
-
-    * Windows only: Modify `src/qwt_series_store.h` to remove `QWT_EXPORT` from the `QwtSeriesStore` class definition in order to build properly.
-      This may be fixed at the time you try this, so do check first to see if it builds without this change.
+* Qwt 6.2
+    * Qwt 6.2:
+        * Get Qwt 6.2 by checking the code out using this subversion command line:
+          $ svn checkout svn://svn.code.sf.net/p/qwt/code/branches/qwt-6.2
+        * Windows only: Modify `src/qwt_series_store.h` to remove `QWT_EXPORT`
+          from the `QwtSeriesStore` class definition in order to build properly.
+          This may be fixed at the time you try this, so do check first to see
+          if it builds without this change.
 
     * Build as normal per Qwt instructions at: http://qwt.sourceforge.net/qwtinstall.html
-
     * Install to standard location - for Windows this is `C:\Qwt-6.2.0-svn` -- this way pysideqwt will know how to find it.
 
 ### Building for Windows
 
-* Add `C:\Program Files\Git\cmd` and `C:\Program Files\Git\usr\bin` to your system environment variables.  (Note: Should remove dependency on unix-like pushd and rmdir tools, and use windows-native versions)
+* Add `C:\Program Files\Git\cmd` and `C:\Program Files\Git\usr\bin` to your system environment PATH variables.  (Note: Should remove dependency on unix-like pushd and rmdir tools, and use windows-native versions)
+* Make sure Python 3 is in your system environment PATH variable.
+* For a faster build, put nmake replacement jom in your path
 * Start a Visual Studio 2017 x64 command line prompt
 * Run setup.bat - this will do the build for you and install pysideqwt into the `site-packages` directory of the Python installation in your path.
 
@@ -40,6 +50,8 @@
 * Run setup.sh -- this will do the build for you and install pysideqwt into the `site-packages` directory of the Python installation in your path.
 
 ### Using Pysideqwt in your python applications
+
+* On Windows, make sure that the <Qwt Dir>/lib directory is in the path, so that the qwt.dll can be found.  If you encounter the error "ImportError: DLL load failed: The specified module could not be found.", it is likely because qwt.dll could not be found.
 
 Once installed, it can be found by your python code using:
 ~~~~

--- a/cmake/Modules/FindQwt.cmake
+++ b/cmake/Modules/FindQwt.cmake
@@ -26,6 +26,8 @@ set(QWTMATHML_LIBRARY_NAMES qwtmathml-qt5 qwtmathml6-qt5 qwtmathml qwtmathml6 qw
 #set(QWT_PATHS
 #    "C:/Qwt-6.2.0-svn"
 #    /usr/local/qwt-6.2.0-svn
+#    "C:/Qwt-6.1.4"
+#    /usr/local/qwt-6.1.4
 #    "C:/Qwt-6.1.3"
 #    /usr/local/qwt-6.1.3
 #    /usr/lib
@@ -38,6 +40,10 @@ set(QWTMATHML_LIBRARY_NAMES qwtmathml-qt5 qwtmathml6-qt5 qwtmathml qwtmathml6 qw
 set(QWT_PATHS
     "C:/Qwt-6.2.0-svn"
     /usr/local/qwt-6.2.0-svn
+    "C:/Qwt-6.1.4"
+    /usr/local/qwt-6.1.4
+    "C:/Qwt-6.1.3"
+    /usr/local/qwt-6.1.3
     /usr/local
     /usr
     "$ENV{LIB}"
@@ -73,6 +79,10 @@ FIND_PATH(QWT_INCLUDE_DIR NAMES qwt.h PATHS
   "${_qwt_fw}/Headers"
   "C:/Qwt-6.2.0-svn/include"
   /usr/local/qwt-6.2.0-svn/include
+  "C:/Qwt-6.1.4/include"
+  /usr/local/qwt-6.1.4/include
+  "C:/Qwt-6.1.3/include"
+  /usr/local/qwt-6.1.3/include
   /usr/include
   /usr/local/include
   /usr/local/include/qt5
@@ -86,6 +96,10 @@ FIND_PATH(QWTMATHML_INCLUDE_DIR NAMES qwt_mathml_text_engine.h PATHS
   "${_qwtmathml_fw}/Headers"
   "C:/Qwt-6.2.0-svn/include"
   /usr/local/qwt-6.2.0-svn/include
+  "C:/Qwt-6.1.4/include"
+  /usr/local/qwt-6.1.4/include
+  "C:/Qwt-6.1.3/include"
+  /usr/local/qwt-6.1.3/include
   /usr/include
   /usr/local/include
   /usr/local/include/qt5

--- a/setup.bat
+++ b/setup.bat
@@ -23,7 +23,7 @@ rm -rf %BUILD_DIR%
 mkdir %BUILD_DIR%
 set CURDIR=%CD%
 cd %BUILD_DIR%
-cmake -H%SRC_DIR% -B. -DQt5_DIR=C:\Qt\Qt5.12.0\5.12.0\msvc2017_64\lib\cmake\Qt5 -G "NMake Makefiles" -DCMAKE_BUILD_TYPE=%CONFIGURATION%
+cmake -H%SRC_DIR% -B. -DQt5_DIR=C:\Qt\Qt5.12.4\5.12.4\msvc2017_64\lib\cmake\Qt5 -G "NMake Makefiles" -DCMAKE_BUILD_TYPE=%CONFIGURATION%
 if %ERRORLEVEL% NEQ 0 goto REPORTERR
 
 set CL=/MP


### PR DESCRIPTION
Changes to support building for Windows.
Tested under Windows 10, with Visual Studio 2017, Qt 5.12.4, PySide2 built from pyside-setup source at tag v5.12.4, and with Qwt 6.2.0-svn.
